### PR TITLE
Add plugin support and optional virtual mail directory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,24 @@ Pre-generated, web-accessible reference documentation -- with abundant **example
 
 Please refer to the *operatingsystem_support* section of [metadata.json](metadata.json) for known, proven-in-production OS compatibility.  This is not an exhaustive list.  You will very likely find that this module runs just fine on other operating system and version combinations, given the proper inputs.  In fact, if you do, please report it back so the metadata can be updated!
 
+### Postfix 3 Compatibility
+
+This module is compatible with both Postfix 2 and 3.  However, its default model is that of Postfix 2 due to its continuing prevalence.  In order to support Postfix 3, you **must** supply the following additional configuration:
+
+```yaml
+# Disable `purge_config_file_path` to preserve these unmanaged but important resources:
+#   - %{config_file_path}/dynamicmaps.cf.d/
+#   - %{config_file_path}/dynamicmaps.cf
+#   - %{config_file_path}/main.cf.proto
+#   - %{config_file_path}/master.cf.proto
+#   - %{config_file_path}/postfix-files
+postfix::purge_config_file_path: false
+
+# Specify a backward compatibility threshold for Postfix
+postfix::global_parameters:
+  compatibility_level: 2
+```
+
 ## Development
 
 Please refer to [CONTRIBUTING](CONTRIBUTING.md) to learn how to hack this module.

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -26,7 +26,7 @@ lookup_options:
     <<: *deep_merge
   postfix::master_processes:
     <<: *deep_merge
-  postfix::plugins:
+  postfix::plugin_packages:
     <<: *deep_merge
 
 # Ensure the package is at least installed

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -26,6 +26,8 @@ lookup_options:
     <<: *deep_merge
   postfix::master_processes:
     <<: *deep_merge
+  postfix::plugins:
+    <<: *deep_merge
 
 # Ensure the package is at least installed
 postfix::package_ensure: present

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -98,6 +98,7 @@
 #
 class postfix::config {
   if 'purged' == $postfix::package_ensure {
+    # Note:  never destroy the $virtual_delivery_dir to avoid destroying mail.
     file { $postfix::config_file_path:
       ensure => absent,
       force  => true,
@@ -146,6 +147,14 @@ class postfix::config {
         ensure  => file,
         content => template("${module_name}/check-file.erb"),
         *       => $postfix::config_file_attributes,
+      }
+    }
+
+    # Manage the optional $virtual_delivery_dir, if used.
+    if undef != $postfix::virtual_delivery_dir {
+      file { $postfix::virtual_delivery_dir:
+        ensure => directory,
+        *      => $postfix::virtual_delivery_dir_attributes,
       }
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -106,14 +106,15 @@ class postfix::config {
     $knockout_prefix = $postfix::config_hash_key_knockout_prefix
 
     # Ensure the configuration directory exists
+    $purge_recurse_limit = $postfix::purge_config_file_path ? {
+      true    => 1,
+      default => undef,
+    }
     file { $postfix::config_file_path:
       ensure       => directory,
       purge        => $postfix::purge_config_file_path,
       recurse      => $postfix::purge_config_file_path,
-      recurselimit => $postfix::purge_config_file_path ? {
-        true    => 1,
-        default => undef,
-      },
+      recurselimit => $purge_recurse_limit,
       *            => $postfix::config_file_path_attributes,
     }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,6 +48,24 @@
 #    password: secret-email-password
 #    dbname: email-database
 #
+#  # Define the MySQL lookup maps, merging in the shared database parameters
+#  postfix::config_files:
+#    lookup_domains.cf:
+#      <<: *postfixLookupDatabase
+#      query: >
+#        SELECT domain FROM domain
+#        WHERE domain = '%s' AND backupmx = '0' AND active = '1'
+#    lookup_users.cf:
+#      <<: *postfixLookupDatabase
+#      query: >
+#        SELECT maildir FROM mailbox
+#        WHERE username = '%s' AND active = '1'
+#    lookup_aliases.cf:
+#      <<: *postfixLookupDatabase
+#      query: >
+#        SELECT goto FROM alias
+#        WHERE address = '%s' AND active = '1'
+#
 #  # Set global parameters to enable proxying the DB connections and define some
 #  # MySQL lookup maps.  Also tell Postfix where and as whom to deliver the
 #  # virtual mail.
@@ -62,28 +80,6 @@
 #    virtual_mailbox_base: *virtual_mail_base_directory
 #    virtual_gid_maps: static:5000
 #    virtual_uid_maps: static:5000
-#
-#  # Define the MySQL lookup maps, merging in the shared database parameters
-#  postfix::config_files:
-#    lookup_domains.cf:
-#      <<: *postfixLookupDatabase
-#      table: domain
-#      select_field: domain
-#      where_field: domain
-#      additional_conditions: and backupmx = '0' and active = '1'
-#    lookup_users.cf:
-#      <<: *postfixLookupDatabase
-#      table: mailbox
-#      select_field: maildir
-#      where_field: username
-#      additional_conditions: and active = '1'
-#      result_format: '%s'
-#    lookup_aliases.cf:
-#      <<: *postfixLookupDatabase
-#      table: alias
-#      select_field: goto
-#      where_field: address
-#      additional_conditions: and active = '1'
 #
 #  # Permit this module to manage the virtual mail delivery base directory
 #  postfix::virtual_delivery_dir: *virtual_mail_base_directory

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -167,7 +167,7 @@ class postfix::config {
       # No default attributes for this directory will be assumed because it is
       # critical that Postfix be able to write to this directory tree.
       if undef == $postfix::virtual_delivery_dir_attributes {
-        fail("When setting postfix::virtual_delivery_dir, you must also provide attributes as a Hash to postfix::virtual_delivery_dir_attributes.")
+        fail('When setting postfix::virtual_delivery_dir, you must also provide attributes as a Hash to postfix::virtual_delivery_dir_attributes.')
       }
 
       file { $postfix::virtual_delivery_dir:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -164,6 +164,12 @@ class postfix::config {
 
     # Manage the optional $virtual_delivery_dir, if used.
     if undef != $postfix::virtual_delivery_dir {
+      # No default attributes for this directory will be assumed because it is
+      # critical that Postfix be able to write to this directory tree.
+      if undef == $postfix::virtual_delivery_dir_attributes {
+        fail("When setting postfix::virtual_delivery_dir, you must also provide attributes as a Hash to postfix::virtual_delivery_dir_attributes.")
+      }
+
       file { $postfix::virtual_delivery_dir:
         ensure => directory,
         *      => $postfix::virtual_delivery_dir_attributes,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -110,7 +110,10 @@ class postfix::config {
       ensure       => directory,
       purge        => $postfix::purge_config_file_path,
       recurse      => $postfix::purge_config_file_path,
-      recurselimit => 1,
+      recurselimit => $postfix::purge_config_file_path ? {
+        true    => 1,
+        default => undef,
+      },
       *            => $postfix::config_file_path_attributes,
     }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,10 +32,14 @@
 #    check_body:
 #      - '/spam\.domain/     REJECT  UCE detected.'
 #
-# @example Use MySQL lookup tables
+# @example Use MySQL lookup tables for virtual mail delivery
 #  ---
 #  classes:
 #    - postfix
+#
+#  # Reusable YAML Values
+#  aliases:
+#    - &virtual_mail_base_directory /var/spool/virtual-mail
 #
 #  # Define a reusable Hash alias for shared database parameters
 #  postfixLookupDatabase: &postfixLookupDatabase
@@ -45,7 +49,8 @@
 #    dbname: email-database
 #
 #  # Set global parameters to enable proxying the DB connections and define some
-#  # MySQL lookup maps.
+#  # MySQL lookup maps.  Also tell Postfix where and as whom to deliver the
+#  # virtual mail.
 #  postfix::global_parameters:
 #    proxy_read_maps: >
 #      $virtual_mailbox_domains,
@@ -54,6 +59,9 @@
 #    virtual_mailbox_domains: proxy:mysql:%{lookup('postfix::config_file_path')}/lookup_domains.cf
 #    virtual_mailbox_maps: proxy:mysql:%{lookup('postfix::config_file_path')}/lookup_users.cf
 #    virtual_alias_maps: proxy:mysql:%{lookup('postfix::config_file_path')}/lookup_aliases.cf
+#    virtual_mailbox_base: *virtual_mail_base_directory
+#    virtual_gid_maps: static:5000
+#    virtual_uid_maps: static:5000
 #
 #  # Define the MySQL lookup maps, merging in the shared database parameters
 #  postfix::config_files:
@@ -76,6 +84,13 @@
 #      select_field: goto
 #      where_field: address
 #      additional_conditions: and active = '1'
+#
+#  # Permit this module to manage the virtual mail delivery base directory
+#  postfix::virtual_delivery_dir: *virtual_mail_base_directory
+#  postfix::virtual_delivery_dir_attributes:
+#    owner: 5000
+#    group: 5000
+#    mode: '0750'
 #
 # @example Add Let's Encrypt certificates
 #  ---

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,8 @@
 #  &nbsp; KEY: VALUE<br>
 #  &nbsp; ...<br>
 #  Default is found in the data directory of this module's source and is applied
-#  per this module's hiera.yaml.
+#  per this module's hiera.yaml.  <strong>NOTE</strong>:  When using Postfix 3+,
+#  you must set an appropriate `compatibility_level`.
 # @param master_processes Full content of master.cf as a Hash with structure:<br>
 #  &nbsp; service-name/service-type:<br>
 #  &nbsp;&nbsp;&nbsp; command:  command name and its arguments<br>
@@ -69,10 +70,23 @@
 # @param package_name Name of the primary postfix package to manage, per your
 #  operating system and distribution.  Default is found in the data directory of
 #  this module's source and is applied per this module's hiera.yaml.
+# @param plugin_packages Hash describing additional postfix packages to install.
+#  This is necessary for Postfix 3+ where features like MySQL or PgSQL are
+#  enabled by which of these additional plugin_packages are installed along with
+#  Postfix.  Such plugin packages are typically named like "postfix-mysql" or
+#  "postfix3-mysql", depending on your upstream repositories' naming
+#  conventions.  This Hash has structure:<br>
+#  &nbsp; /^postfix.*-.+$/:<br>
+#  &nbsp;&nbsp;&nbsp; ensure:  OPTIONAL, https://puppet.com/docs/puppet/latest/types/package.html#package-attribute-ensure<br>
+#  &nbsp;&nbsp;&nbsp; provider:  OPTIONAL, https://puppet.com/docs/puppet/latest/types/package.html#package-attribute-provider<br>
+#  &nbsp;&nbsp;&nbsp; source:  OPTIONAL, https://puppet.com/docs/puppet/latest/types/package.html#package-attribute-source<br>
+#  &nbsp; ...<br>
+#  By default, no plugin packages are installed; you must indicate all Postfix
+#  plugins that you wish to install.
 # @param purge_config_file_path Indicates whether to ensure that only Puppet-
 #  managed configuration files exist in `config_file_path`.  Default is found in
 #  the data directory of this module's source and is applied per this module's
-#  hiera.yaml.
+#  hiera.yaml.  <strong>WARNING</strong>:  Set this to `false` for Postfix 3+.
 # @param service_enable Indicates whether the postfix service will self-start
 #  on node restart.  Default is found in the data directory of this module's
 #  source and is applied per this module's hiera.yaml.
@@ -94,6 +108,26 @@
 #  ---
 #  classes:
 #    - postfix
+#
+# @example Minimally install Postfix 3 with PCRE and MySQL support
+#  # This fictional upstream repository uses the name 'postfix' for Postfix
+#  # version 2.x and a different name, 'postfix3', for Postfix 3 packages.  Both
+#  # use the same service name, 'postfix' (the default).
+#  ---
+#  classes:
+#    - postfix
+#
+#  postfix::package_name: postfix3
+#
+#  # You MUST disable purge_config_file_path for Postfix 3, for now.  If you
+#  # fail to do so, some important -- unmanaged -- configuration files will be
+#  # destroyed.
+#  postfix::purge_config_file_path: false
+#
+#  # Add Postfix plugin support for PCRE and MySQL
+#  postfix::plugin_packages:
+#    postfix3-pcre: {}
+#    postfix3-mysql: {}
 #
 class postfix(
   Hash[String[4], Any]        $config_file_attributes,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,17 @@
 # @param service_name Name of the service to manage when `service_managed` is
 #  enabled.  Default is found in the data directory of this module's source and
 #  is applied per this module's hiera.yaml.
+# @param virtual_delivery_dir Fully-qualified path to the base directory for all
+#  <em>virtual</em> mail delivery.  This directory -- and all predecessors --
+#  must be writable to the user as whom postfix runs or its primary group.  As
+#  an optional parameter, there is no default value, which has no effect.
+# @param virtual_delivery_dir_attributes Puppet attributes to apply to
+#  `virtual_delivery_dir` as a Hash with structure:<br>
+#  &nbsp; KEY: VALUE<br>
+#  &nbsp; ...<br>
+#  where KEY is any supported attribute from https://puppet.com/docs/puppet/latst/types/file.html#file-attributes
+#  Users generally need to add `owner`, `group`, and `mode`.  As an optional
+#  parameter, there is no default value, which has no effect.
 #
 # @see http://www.postfix.org/master.5.html
 # @see http://www.postfix.org/postconf.5.html

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,10 +138,6 @@ class postfix(
       Optional['provider'] => String[1],
       Optional['source']   => String[1],
   }]]]                           $plugin_packages                 = undef,
-  Optional[Hash[
-    String[1],
-    Hash[String[1], Any]
-  ]]                             $spool_subdir_attributes         = undef,
   Optional[Stdlib::Absolutepath] $virtual_delivery_dir            = undef,
   Optional[Hash[String[1], Any]] $virtual_delivery_dir_attributes = undef,
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,14 +96,14 @@
 #    - postfix
 #
 class postfix(
-  Hash[String[4], Any]       $config_file_attributes,
-  String[3]                  $config_file_path,
-  Hash[String[4], Any]       $config_file_path_attributes,
-  Pattern[/^-+$/]            $config_hash_key_knockout_prefix,
+  Hash[String[4], Any]        $config_file_attributes,
+  String[3]                   $config_file_path,
+  Hash[String[4], Any]        $config_file_path_attributes,
+  Pattern[/^-+$/]             $config_hash_key_knockout_prefix,
   Hash[
     Pattern[/^-*[A-Za-z0-9_]+$/],
     Variant[String, Integer]
-  ]                          $global_parameters,
+  ]                           $global_parameters,
   Hash[
     Pattern[/^-*[a-z]+\/(inet|unix|fifo|pass)$/],
     Struct[{
@@ -113,24 +113,31 @@ class postfix(
       Optional['chroot']  => Enum['y', 'n'],
       Optional['wakeup']  => Variant[Pattern[/^(0|[1-9][0-9]*)\??$/], Integer],
       Optional['maxproc'] => Integer,
-  }]]                        $master_processes,
-  String                     $package_ensure,
-  String[2]                  $package_name,
-  Boolean                    $purge_config_file_path,
-  Boolean                    $service_enable,
-  Enum['running', 'stopped'] $service_ensure,
-  Boolean                    $service_managed,
-  String[2]                  $service_name,
+  }]]                         $master_processes,
+  String                      $package_ensure,
+  String[2]                   $package_name,
+  Boolean                     $purge_config_file_path,
+  Boolean                     $service_enable,
+  Enum['running', 'stopped']  $service_ensure,
+  Boolean                     $service_managed,
+  String[2]                   $service_name,
   Optional[Hash[
     String[2],
     Array[String[2]]
-  ]]                         $check_files  = undef,
+  ]]                          $check_files      = undef,
   Optional[Hash[
     String[2],
     Hash[
       Pattern[/^-*[A-Za-z0-9_]+$/],
       Any
-  ]]]                        $config_files = undef,
+  ]]]                         $config_files     = undef,
+  Optional[Hash[
+    Pattern[/^postfix.*-.+$/],
+    Struct[{
+      Optional['ensure']   => String[1],
+      Optional['provider'] => String[1],
+      Optional['source']   => String[1],
+  }]]]                        $plugin_packages = undef,
 ) {
   class { '::postfix::package': }
   -> class { '::postfix::config': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,14 +96,14 @@
 #    - postfix
 #
 class postfix(
-  Hash[String[4], Any]        $config_file_attributes,
-  String[3]                   $config_file_path,
-  Hash[String[4], Any]        $config_file_path_attributes,
-  Pattern[/^-+$/]             $config_hash_key_knockout_prefix,
+  Hash[String[4], Any]           $config_file_attributes,
+  String[3]                      $config_file_path,
+  Hash[String[4], Any]           $config_file_path_attributes,
+  Pattern[/^-+$/]                $config_hash_key_knockout_prefix,
   Hash[
     Pattern[/^-*[A-Za-z0-9_]+$/],
     Variant[String, Integer]
-  ]                           $global_parameters,
+  ]                              $global_parameters,
   Hash[
     Pattern[/^-*[a-z]+\/(inet|unix|fifo|pass)$/],
     Struct[{
@@ -113,31 +113,37 @@ class postfix(
       Optional['chroot']  => Enum['y', 'n'],
       Optional['wakeup']  => Variant[Pattern[/^(0|[1-9][0-9]*)\??$/], Integer],
       Optional['maxproc'] => Integer,
-  }]]                         $master_processes,
-  String                      $package_ensure,
-  String[2]                   $package_name,
-  Boolean                     $purge_config_file_path,
-  Boolean                     $service_enable,
-  Enum['running', 'stopped']  $service_ensure,
-  Boolean                     $service_managed,
-  String[2]                   $service_name,
+  }]]                            $master_processes,
+  String                         $package_ensure,
+  String[2]                      $package_name,
+  Boolean                        $purge_config_file_path,
+  Boolean                        $service_enable,
+  Enum['running', 'stopped']     $service_ensure,
+  Boolean                        $service_managed,
+  String[2]                      $service_name,
   Optional[Hash[
     String[2],
     Array[String[2]]
-  ]]                          $check_files      = undef,
+  ]]                             $check_files                     = undef,
   Optional[Hash[
     String[2],
     Hash[
       Pattern[/^-*[A-Za-z0-9_]+$/],
       Any
-  ]]]                         $config_files     = undef,
+  ]]]                            $config_files                    = undef,
   Optional[Hash[
     Pattern[/^postfix.*-.+$/],
     Struct[{
       Optional['ensure']   => String[1],
       Optional['provider'] => String[1],
       Optional['source']   => String[1],
-  }]]]                        $plugin_packages = undef,
+  }]]]                           $plugin_packages                 = undef,
+  Optional[Hash[
+    String[1],
+    Hash[String[1], Any]
+  ]]                             $spool_subdir_attributes         = undef,
+  Optional[Stdlib::Absolutepath] $virtual_delivery_dir            = undef,
+  Optional[Hash[String[1], Any]] $virtual_delivery_dir_attributes = undef,
 ) {
   class { '::postfix::package': }
   -> class { '::postfix::config': }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -11,19 +11,34 @@
 #  ---
 #  classes:
 #    - postfix
+#
 #  postfix::package_ensure: latest
 #
 # @example Uninstall everything postfix-related but retain its configuration
 #  ---
 #  classes:
 #    - postfix
+#
 #  postfix::package_ensure: absent
 #
 # @example Uninstall everything postfix-related and destroy its configuration
 #  ---
 #  classes:
 #    - postfix
+#
 #  postfix::package_ensure: purged
+#
+# @example Install some plugins and keep them up-to-date
+#  ---
+#  classes:
+#    - postfix
+#
+#  postfix::package_ensure: latest
+#  postfix::plugin_packages:
+#    postfix-ldap:
+#      ensure: latest
+#    postfix-perl-scripts:
+#      ensure: latest
 #
 class postfix::package {
   $default_plugin_attributes = {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -26,9 +26,29 @@
 #  postfix::package_ensure: purged
 #
 class postfix::package {
+  $default_plugin_attributes = {
+    ensure  => present,
+    require => Package['postfix'],
+    tag     => [ 'postfix-plugin', ],
+  }
+
   package { 'postfix':
     ensure => $postfix::package_ensure,
     name   => $postfix::package_name,
+  }
+
+  pick($postfix::plugin_packages, {}).each | String $name, Hash $attrs | {
+    if $postfix::package_ensure in ['absent', 'purged'] {
+      package { $name:
+        ensure => $postfix::package_ensure,
+        before => [ Package['postfix'], ],
+      }
+    } else {
+      package {
+        default: *=> $default_plugin_attributes,;
+        $name:   *=> $attrs,;
+      }
+    }
   }
 }
 # vim: syntax=puppet:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -31,6 +31,9 @@ class postfix::service {
       enable    => $postfix::service_enable,
       subscribe => [ Package['postfix'], ],
     }
+
+    # Ensure that changes to plugins also trigger service restarts
+    Package <| tag == 'postfix-plugin' |> ~> Service['postfix']
   }
 }
 # vim: syntax=puppet:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "author": "William W. Kimball, Jr., MBA, MSIS",
   "name": "wwkimball-postfix",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "summary": "Fully manages postfix with full Hiera support",
   "license": "Apache-2.0",
   "project_page": "https://github.com/wwkimball/wwkimball-postfix",

--- a/spec/classes/config.yaml
+++ b/spec/classes/config.yaml
@@ -356,6 +356,22 @@ describe:
               /etc/postfix/master.cf: {}
               /etc/postfix/main.cf: {}
 
+    'config.pp manage virtual mail delivery directory':
+      let:
+        params:
+          virtual_delivery_dir: /var/spool/virtmail
+          virtual_delivery_dir_attributes:
+            owner: postfix
+            group: mail
+            mode: '0750'
+      tests:
+        contain_file:
+          /var/spool/virtmail:
+            with:
+              owner: postfix
+              group: mail
+              mode: '0750'
+
     'config.pp negative tests':
       variants:
         'attempt to make managed directories something else':
@@ -367,5 +383,12 @@ describe:
           tests:
             compile:
               and_raise_error: !ruby/regexp /The attribute 'ensure' has already been set/
+        'attempt to manage virtual mail delivery directory without attributes':
+          let:
+            params:
+              virtual_delivery_dir: /var/spool/virtmail
+          tests:
+            compile:
+              and_raise_error: !ruby/regexp /When setting postfix::virtual_delivery_dir, you must also provide attributes as a Hash to postfix::virtual_delivery_dir_attributes/
 
 # vim: syntax=yaml:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai

--- a/spec/classes/package.yaml
+++ b/spec/classes/package.yaml
@@ -58,4 +58,29 @@ describe:
                 compile:
                   and_raise_error: !ruby/regexp /parameter 'package_name' expects a String value, got Boolean/
 
+    'package.pp with plugins':
+      let:
+        params:
+          plugin_packages:
+            postfix-mysql: {}
+            postfix-pcre: {}
+      tests:
+        have_package_resource_count: 3
+        contain_package:
+          postfix: present
+          postfix-mysql: present
+          postfix-pcre: present
+      variants:
+        'uninstall a plugin':
+          let:
+            params:
+              plugin_packages:
+                postfix-pcre:
+                  ensure: absent
+          tests:
+            contain_package:
+              postfix: present
+              postfix-mysql: present
+              postfix-pcre: absent
+
 # vim: syntax=yaml:tabstop=2:softtabstop=2:shiftwidth=2:expandtab:ai


### PR DESCRIPTION
Plugin support targets Postfix 3 while virtual mail delivery directory handling is useful for all versions of Postfix that support virtual mail handling.